### PR TITLE
Equality Koan wasn't using correct operator, lists example had filled-in type already.

### DIFF
--- a/Koans/02-Equality.idr
+++ b/Koans/02-Equality.idr
@@ -5,7 +5,7 @@ equalityEq : Bool
 equalityEq = ?fillme1 == True
 
 equalityNeq : Bool
-equalityNeq = ?fillme2 == 3
+equalityNeq = ?fillme2 /= 3
 
 equalityGeq : Bool
 equalityGeq = ?fillme3 >= 4

--- a/Koans/05-Lists.idr
+++ b/Koans/05-Lists.idr
@@ -2,7 +2,7 @@
 module Koans.Lists
 
 -- | What is the type of this list.
-nats : List Integer
+nats : ?someType
 nats = [0,1,2,3,4,5,6,7,9]
 
 -- | Reproduce the list [0,1,3,5,7,9,2,4,6,8] using the following functions.


### PR DESCRIPTION
The "equalityNeq" Koan should probably have had "/=" as the operator, not
"==".
