### PR TITLE
Fix a couple of bugs, disambiguate namespaces

### DIFF
--- a/Koans/04-Ranges.idr
+++ b/Koans/04-Ranges.idr
@@ -8,7 +8,7 @@ stepUp : Bool
 stepUp = ?fillme2 == [3,6..20]
 
 stepDown : Bool
-stepDown = ?fillme3 [20,17..1]
+stepDown = ?fillme3 == [20,17..1]
 
 stopMe : List Integer
 stopMe = ?fillme4 [1..]

--- a/Koans/05-Lists.idr
+++ b/Koans/05-Lists.idr
@@ -36,13 +36,13 @@ lengthOList : Bool
 lengthOList = ?fillme8 == length [1,2,3,4,5]
 
 reverseTheList : Bool
-reverseTheList = ?fillme9 reverse [1,2,3,4,5]
+reverseTheList = ?fillme9 == reverse [1,2,3,4,5]
 
 first3 : Bool
 first3 = ?fillme10 == take 3 [1..10]
 
 drop3 : Bool
-drop3 = ?fillme11 drop 3 [1..10]
+drop3 = ?fillme11 == drop 3 [1..10]
 
 countAllTheNumbers : Bool
 countAllTheNumbers = ?fillme12 == sum [1..10]
@@ -54,7 +54,7 @@ elementOrNot : Bool
 elementOrNot = elem 4 ?fillme14 == True
 
 -- | Make this function true
-stopPete : List Nat
+stopPete : Bool
 stopPete = ?fillme15 (repeat 3) == [3,3,3,3]
 
 -- --------------------------------------------------------------------- [ EOF ]

--- a/Koans/05-Lists.idr
+++ b/Koans/05-Lists.idr
@@ -21,22 +21,22 @@ zeroOddsEvens = ?fillme2 ++ odds ++ ?fillme3 == [0,1,3,5,7,9,2,4,6,8]
 -- | Complete the result of following functions.
 
 headOList : Bool
-headOList = ?fillme4 == head [5,4,3,2,1]
+headOList = ?fillme4 == Vect.head [5,4,3,2,1]
 
 tailOList : Bool
-tailOList = ?fillme5 == tail [0,1,2,3,4,5]
+tailOList = ?fillme5 == Vect.tail [0,1,2,3,4,5]
 
 lastOList : Bool
-lastOList = ?fillme6 == last [5,4,3,2,1]
+lastOList = ?fillme6 == Vect.last [5,4,3,2,1]
 
 initOList : Bool
-initOList = ?fillme7 == init [1,2,3,4,5,6]
+initOList = ?fillme7 == Vect.init [1,2,3,4,5,6]
 
 lengthOList : Bool
-lengthOList = ?fillme8 == length [1,2,3,4,5]
+lengthOList = ?fillme8 == List.length [1,2,3,4,5]
 
 reverseTheList : Bool
-reverseTheList = ?fillme9 == reverse [1,2,3,4,5]
+reverseTheList = ?fillme9 == List.reverse [1,2,3,4,5]
 
 first3 : Bool
 first3 = ?fillme10 == take 3 [1..10]
@@ -51,7 +51,7 @@ timesAllTheNnumbers : Bool
 timesAllTheNnumbers = ?fillme13 == product [1..10]
 
 elementOrNot : Bool
-elementOrNot = elem 4 ?fillme14 == True
+elementOrNot = List.elem 4 ?fillme14 == True
 
 -- | Make this function true
 stopPete : Bool

--- a/Koans/06-ListComprehensions.idr
+++ b/Koans/06-ListComprehensions.idr
@@ -2,7 +2,7 @@ module Koans.ListComprehensions
 
 -- | What is the result of the List Comprehension.
 listCompZero : Bool
-listCompZero = ?fillme1 == [ x + x | x <- [1..5] ]
+listCompZero = ?fillme1 == with Classes [ x + x | x <- [1..5] ]
 
 -- | Write a list comprehension that returns all the numbers divisible by four, doubled.
 myFirstListComp : List Integer -> List Integer


### PR DESCRIPTION
The first commit adds some missing (==)'s and fixes a wrong type spec.

The second one makes is easier for the Idris beginner to just fill the metavars without having to disambiguate the namespace of some functions (like (+), which is defined in Fin and Classes; and the List ones, which are also available for Vect, Stream...).
