### PR TITLE
Update Koans to be easier on 1.2.0

### DIFF
--- a/Koans/01-Arithmetic.idr
+++ b/Koans/01-Arithmetic.idr
@@ -14,13 +14,13 @@ multiplication = ?fillme2 == 10 * 32
 
 -- | In what year did the Colourised version of Ivor the Engine first air?
 subtraction : Bool     
-subtraction = 1977 - ?fillme3 == 3
+subtraction = minus 1977 ?fillme3 == 3
 
 -- | 26 B/W episodes of Ivor the Engine were discovered in a Pig shed
 -- in 2010. There were two seasons. How many episodes per season were
 -- there?
 division : Bool
-division = 26 / ?fillme4 == 2
+division = div 26 ?fillme4 == 2
 
 -- | There were 32 B/W episodes of ten minutes each, and 40 colour
 -- episodes of five minutes each. How many minutes of Ivor the Engine

--- a/Koans/05-Lists.idr
+++ b/Koans/05-Lists.idr
@@ -1,6 +1,8 @@
 -- | Exercises on Lists
 module Koans.Lists
 
+import Data.Vect
+
 -- | What is the type of this list.
 nats : ?someType
 nats = [0,1,2,3,4,5,6,7,9]

--- a/Koans/07-Tuples.idr
+++ b/Koans/07-Tuples.idr
@@ -1,6 +1,7 @@
 module Koans.Tuples
 
 import Data.Vect
+
 -- Complete the following functions
 
 firstPair : Bool

--- a/Koans/07-Tuples.idr
+++ b/Koans/07-Tuples.idr
@@ -1,5 +1,6 @@
 module Koans.Tuples
 
+import Data.Vect
 -- Complete the following functions
 
 firstPair : Bool

--- a/Koans/08-HigherOrderFunctions.idr
+++ b/Koans/08-HigherOrderFunctions.idr
@@ -28,7 +28,7 @@ mySecondScan : Bool
 mySecondScan = scanl ?fillme7 5 [1,2,10,1] == [5,5,5,10,10]
 
 myThirdScan : Bool
-myThirdScan = scanl (/) 64 [4,2,4] == ?fillme8
+myThirdScan = scanl (div) 64 [4,2,4] == ?fillme8
 
 
 -- TODO Add examples for scanr and foldr


### PR DESCRIPTION
Nat's implementation of `-` has changed to require a proof that the second argument is less than or equal to the first. This seems a bit too heavy for the first Koan, so I substituted `minus`.

There is now no definition of `/` for Nat/Integer so I've replaced it with `div`.

